### PR TITLE
Bump Neo4j version (5.1.0) for simple cluster

### DIFF
--- a/simple-cluster-ssl.yml
+++ b/simple-cluster-ssl.yml
@@ -21,10 +21,10 @@ networks:
 
 volumes:
   trusted_certs:
-  core1_priv:
-  core2_priv:
-  core3_priv:
-  read1_priv:
+  srv1_priv:
+  srv2_priv:
+  srv3_priv:
+  srv4_priv:
 
 services:
 
@@ -32,22 +32,34 @@ services:
     image: nginx
     volumes:
       - trusted_certs:/trusted:rw
-      - core1_priv:/core1:rw
-      - core2_priv:/core2:rw
-      - core3_priv:/core3:rw
-      - read1_priv:/read1:rw
+      - srv1_priv:/srv1:rw
+      - srv2_priv:/srv2:rw
+      - srv3_priv:/srv3:rw
+      - srv4_priv:/srv4:rw
     command:
       - bash
       - -c
       - |
-        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core1" -keyout /core1/private.pem -out /trusted/core1.pem
-        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core2" -keyout /core2/private.pem -out /trusted/core2.pem
-        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core3" -keyout /core3/private.pem -out /trusted/core3.pem
-        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=read1" -keyout /read1/private.pem -out /trusted/read1.pem
+        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core1" -keyout /srv1/private.key -out /srv1/public.crt
+        chmod 666 /srv1/private.key
+        chmod 666 /srv1/public.crt
+        cp /srv1/public.crt /trusted/srv1_public.crt
+        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core2" -keyout /srv2/private.key -out /srv2/public.crt
+        chmod 666 /srv2/private.key
+        chmod 666 /srv2/public.crt
+        cp /srv2/public.crt /trusted/srv2_public.crt
+        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=core3" -keyout /srv3/private.key -out /srv3/public.crt
+        chmod 666 /srv3/private.key
+        chmod 666 /srv3/public.crt
+        cp /srv3/public.crt /trusted/srv3_public.crt
+        openssl req -out -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/C=de/L=BY/L=Munic/O=Neo4j/CN=read1" -keyout /srv4/private.key -out /srv4/public.crt
+        chmod 666 /srv4/private.key
+        chmod 666 /srv4/public.crt
+        cp /srv4/public.crt /trusted/srv4_public.crt
 
-  core1:
-    hostname: core1
-    image: neo4j:4.2-enterprise
+  srv1:
+    hostname: srv1
+    image: neo4j:5.1.0-enterprise
     depends_on:
       - ssl
     networks:
@@ -57,170 +69,191 @@ services:
       - 6477:6477
       - 7687:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core1/conf:/conf
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core1/data:/data
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core1/logs:/logs
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core1/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv1/conf:/conf
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv1/data:/data
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv1/logs:/logs
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv1/metrics:/metrics
       - trusted_certs:/trusted_certs
-      - core1_priv:/priv
+      - srv1_priv:/priv
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7474
-      - NEO4J_dbms_connector_https_listen__address=:6477
-      - NEO4J_dbms_connector_bolt_listen__address=:7687
-      - NEO4J_dbms_ssl.policy_cluster_enabled=true
-      - NEO4J_dbms_ssl.policy_cluster_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_cluster_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_cluster_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_backup_enabled=true
-      - NEO4J_dbms_ssl.policy_backup_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_backup_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_backup_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_bolt_enabled=true
-      - NEO4J_dbms_ssl.policy_bolt_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_bolt_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_bolt_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_https_enabled=true
-      - NEO4J_dbms_ssl.policy_https_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_https_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_https_trusted__dir=/trusted_certs
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv1
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000,srv4:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_dbms_ssl_policy_cluster_enabled=true
+      - NEO4J_dbms_ssl_policy_cluster_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_cluster_private__key=private.key
+      - NEO4J_dbms_ssl_policy_cluster_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_cluster_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_backup_enabled=true
+      - NEO4J_dbms_ssl_policy_backup_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_backup_private__key=private.key
+      - NEO4J_dbms_ssl_policy_backup_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_backup_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_bolt_enabled=true
+      - NEO4J_dbms_ssl_policy_bolt_client__auth=NONE
+      - NEO4J_server_bolt_tls__level=REQUIRED
+      - NEO4J_dbms_ssl_policy_bolt_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_bolt_private__key=private.key
+      - NEO4J_dbms_ssl_policy_bolt_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_bolt_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_https_enabled=true
+      - NEO4J_dbms_ssl_policy_https_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_https_private__key=private.key
+      - NEO4J_dbms_ssl_policy_https_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_https_trusted__dir=/trusted_certs
 
-  core2:
-    hostname: core2
-    image: neo4j:4.2-enterprise
+  srv2:
+    hostname: srv2
+    image: neo4j:5.1.0-enterprise
     depends_on:
       - ssl
     networks:
       - cluster_net
     ports:
-      - 7475:7475
-      - 6478:6478
-      - 7688:7688
+      - 7475:7474
+      - 6478:6477
+      - 7688:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core2/conf:/conf
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core2/data:/data
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core2/logs:/logs
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core2/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv2/conf:/conf
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv2/data:/data
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv2/logs:/logs
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv2/metrics:/metrics
       - trusted_certs:/trusted_certs
-      - core2_priv:/priv
+      - srv2_priv:/priv
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7475
-      - NEO4J_dbms_connector_https_listen__address=:6478
-      - NEO4J_dbms_connector_bolt_listen__address=:7688
-      - NEO4J_dbms_ssl.policy_cluster_enabled=true
-      - NEO4J_dbms_ssl.policy_cluster_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_cluster_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_cluster_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_backup_enabled=true
-      - NEO4J_dbms_ssl.policy_backup_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_backup_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_backup_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_bolt_enabled=true
-      - NEO4J_dbms_ssl.policy_bolt_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_bolt_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_bolt_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_https_enabled=true
-      - NEO4J_dbms_ssl.policy_https_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_https_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_https_trusted__dir=/trusted_certs
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv2
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000,srv4:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_dbms_ssl_policy_cluster_enabled=true
+      - NEO4J_dbms_ssl_policy_cluster_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_cluster_private__key=private.key
+      - NEO4J_dbms_ssl_policy_cluster_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_cluster_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_backup_enabled=true
+      - NEO4J_dbms_ssl_policy_backup_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_backup_private__key=private.key
+      - NEO4J_dbms_ssl_policy_backup_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_backup_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_bolt_enabled=true
+      - NEO4J_dbms_ssl_policy_bolt_client__auth=NONE
+      - NEO4J_server_bolt_tls__level=REQUIRED
+      - NEO4J_dbms_ssl_policy_bolt_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_bolt_private__key=private.key
+      - NEO4J_dbms_ssl_policy_bolt_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_bolt_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_https_enabled=true
+      - NEO4J_dbms_ssl_policy_https_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_https_private__key=private.key
+      - NEO4J_dbms_ssl_policy_https_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_https_trusted__dir=/trusted_certs
 
-  core3:
-    hostname: core3
-    image: neo4j:4.2-enterprise
+  srv3:
+    hostname: srv3
+    image: neo4j:5.1.0-enterprise
     depends_on:
       - ssl
     networks:
       - cluster_net
     ports:
-      - 7476:7476
-      - 6479:6479
-      - 7689:7689
+      - 7476:7474
+      - 6479:6477
+      - 7689:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core3/conf:/conf
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core3/data:/data
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core3/logs:/logs
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-core3/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv3/conf:/conf
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv3/data:/data
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv3/logs:/logs
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv3/metrics:/metrics
       - trusted_certs:/trusted_certs
-      - core3_priv:/priv
+      - srv3_priv:/priv
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7476
-      - NEO4J_dbms_connector_https_listen__address=:6479
-      - NEO4J_dbms_connector_bolt_listen__address=:7689
-      - NEO4J_dbms_ssl.policy_cluster_enabled=true
-      - NEO4J_dbms_ssl.policy_cluster_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_cluster_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_cluster_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_backup_enabled=true
-      - NEO4J_dbms_ssl.policy_backup_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_backup_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_backup_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_bolt_enabled=true
-      - NEO4J_dbms_ssl.policy_bolt_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_bolt_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_bolt_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_https_enabled=true
-      - NEO4J_dbms_ssl.policy_https_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_https_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_https_trusted__dir=/trusted_certs
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv3
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000,srv4:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_dbms_ssl_policy_cluster_enabled=true
+      - NEO4J_dbms_ssl_policy_cluster_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_cluster_private__key=private.key
+      - NEO4J_dbms_ssl_policy_cluster_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_cluster_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_backup_enabled=true
+      - NEO4J_dbms_ssl_policy_backup_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_backup_private__key=private.key
+      - NEO4J_dbms_ssl_policy_backup_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_backup_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_bolt_enabled=true
+      - NEO4J_dbms_ssl_policy_bolt_client__auth=NONE
+      - NEO4J_server_bolt_tls__level=REQUIRED
+      - NEO4J_dbms_ssl_policy_bolt_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_bolt_private__key=private.key
+      - NEO4J_dbms_ssl_policy_bolt_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_bolt_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_https_enabled=true
+      - NEO4J_dbms_ssl_policy_https_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_https_private__key=private.key
+      - NEO4J_dbms_ssl_policy_https_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_https_trusted__dir=/trusted_certs
 
-  read1:
-    hostname: read1
-    image: neo4j:4.2-enterprise
+  srv4:
+    hostname: srv4
+    image: neo4j:5.1.0-enterprise
     depends_on:
       - ssl
     networks:
       - cluster_net
     ports:
-      - 7477:7477
-      - 6480:6480
-      - 7690:7690
+      - 7477:7474
+      - 6480:6477
+      - 7690:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-read1/conf:/conf
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-read1/data:/data
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-read1/logs:/logs
-      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-read1/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv4/conf:/conf
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv4/data:/data
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv4/logs:/logs
+      - $HOME/tmp/docker/cluster-simple-ssl/neo4j-srv4/metrics:/metrics
       - trusted_certs:/trusted_certs
-      - read1_priv:/priv
+      - srv4_priv:/priv
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=READ_REPLICA
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7477
-      - NEO4J_dbms_connector_https_listen__address=:6480
-      - NEO4J_dbms_connector_bolt_listen__address=:7690
-      - NEO4J_dbms_allow__upgrade=true
-      - NEO4J_dbms_ssl.policy_cluster_enabled=true
-      - NEO4J_dbms_ssl.policy_cluster_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_cluster_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_cluster_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_backup_enabled=true
-      - NEO4J_dbms_ssl.policy_backup_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_backup_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_backup_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_bolt_enabled=true
-      - NEO4J_dbms_ssl.policy_bolt_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_bolt_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_bolt_trusted__dir=/trusted_certs
-      - NEO4J_dbms_ssl.policy_https_enabled=true
-      - NEO4J_dbms_ssl.policy_https_base__directory=/priv
-      - NEO4J_dbms_ssl.policy_https_private__key=private.pem
-      - NEO4J_dbms_ssl.policy_https_trusted__dir=/trusted_certs
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv4
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000,srv4:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_dbms_ssl_policy_cluster_enabled=true
+      - NEO4J_dbms_ssl_policy_cluster_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_cluster_private__key=private.key
+      - NEO4J_dbms_ssl_policy_cluster_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_cluster_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_backup_enabled=true
+      - NEO4J_dbms_ssl_policy_backup_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_backup_private__key=private.key
+      - NEO4J_dbms_ssl_policy_backup_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_backup_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_bolt_client__auth=NONE
+      - NEO4J_server_bolt_tls__level=REQUIRED
+      - NEO4J_dbms_ssl_policy_bolt_enabled=true
+      - NEO4J_dbms_ssl_policy_bolt_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_bolt_private__key=private.key
+      - NEO4J_dbms_ssl_policy_bolt_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_bolt_trusted__dir=/trusted_certs
+      - NEO4J_dbms_ssl_policy_https_enabled=true
+      - NEO4J_dbms_ssl_policy_https_base__directory=/priv
+      - NEO4J_dbms_ssl_policy_https_private__key=private.key
+      - NEO4J_dbms_ssl_policy_https_public__certificate=public.crt
+      - NEO4J_dbms_ssl_policy_https_trusted__dir=/trusted_certs
 

--- a/simple-cluster.yml
+++ b/simple-cluster.yml
@@ -5,9 +5,9 @@ networks:
 
 services:
 
-  core1:
-    hostname: core1
-    image: neo4j:4.4-enterprise
+  srv1:
+    hostname: srv1
+    image: neo4j:5.1.0-enterprise
     networks:
       - cluster_net
     ports:
@@ -15,103 +15,69 @@ services:
       - 6477:6477
       - 7687:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple/neo4j-core1/conf:/conf
-      - $HOME/tmp/docker/cluster-simple/neo4j-core1/data:/data
-      - $HOME/tmp/docker/cluster-simple/neo4j-core1/logs:/logs
-      - $HOME/tmp/docker/cluster-simple/neo4j-core1/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv1/conf:/var/lib/neo4j/conf
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv1/data:/var/lib/neo4j/data
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv1/logs:/var/lib/neo4j/logs
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv1/metrics:/var/lib/neo4j/metrics
       - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7474
-      - NEO4J_dbms_connector_https_listen__address=:6477
-      - NEO4J_dbms_connector_bolt_listen__address=:7687
-      - NEO4J_dbms_allow__upgrade=true
-      - NEO4JLABS_PLUGINS=["apoc"]
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv1
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
 
-  core2:
-    hostname: core2
-    image: neo4j:4.4-enterprise
+  srv2:
+    hostname: srv2
+    image: neo4j:5.1.0-enterprise
     networks:
       - cluster_net
     ports:
-      - 7475:7475
-      - 6478:6478
-      - 7688:7688
+      - 7475:7474
+      - 6478:6477
+      - 7688:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple/neo4j-core2/conf:/conf
-      - $HOME/tmp/docker/cluster-simple/neo4j-core2/data:/data
-      - $HOME/tmp/docker/cluster-simple/neo4j-core2/logs:/logs
-      - $HOME/tmp/docker/cluster-simple/neo4j-core2/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv2/conf:/var/lib/neo4j/conf
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv2/data:/var/lib/neo4j/data
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv2/logs:/var/lib/neo4j/logs
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv2/metrics:/metrics
       - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7475
-      - NEO4J_dbms_connector_https_listen__address=:6478
-      - NEO4J_dbms_connector_bolt_listen__address=:7688
-      - NEO4J_dbms_allow__upgrade=true
-      - NEO4JLABS_PLUGINS=["apoc"]
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv2
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
 
-  core3:
-    hostname: core3
-    image: neo4j:4.4-enterprise
+  srv3:
+    hostname: srv3
+    image: neo4j:5.1.0-enterprise
     networks:
       - cluster_net
     ports:
-      - 7476:7476
-      - 6479:6479
-      - 7689:7689
+      - 7476:7474
+      - 6479:6477
+      - 7689:7687
     volumes:
-      - $HOME/tmp/docker/cluster-simple/neo4j-core3/conf:/conf
-      - $HOME/tmp/docker/cluster-simple/neo4j-core3/data:/data
-      - $HOME/tmp/docker/cluster-simple/neo4j-core3/logs:/logs
-      - $HOME/tmp/docker/cluster-simple/neo4j-core3/metrics:/metrics
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv3/conf:/var/lib/neo4j/conf
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv3/data:/var/lib/neo4j/data
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv3/logs:/var/lib/neo4j/logs
+      - $HOME/tmp/docker/cluster-simple/neo4j-srv3/metrics:/var/lib/neo4j/metrics
       - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=CORE
+      - NEO4J_server_cluster_system__database__mode=PRIMARY
+      - NEO4J_initial_server_mode__constraint=PRIMARY
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
-      - NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime=3
-      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7476
-      - NEO4J_dbms_connector_https_listen__address=:6479
-      - NEO4J_dbms_connector_bolt_listen__address=:7689
-      - NEO4J_dbms_allow__upgrade=true
-      - NEO4JLABS_PLUGINS=["apoc"]
+      - NEO4J_server_default__listen__address=0.0.0.0
+      - NEO4J_server_default__advertised__address=srv3
+      - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
+      - NEO4J_initial_dbms_default__primaries__count=3
 
-  read1:
-    hostname: read1
-    image: neo4j:4.4-enterprise
-    networks:
-      - cluster_net
-    ports:
-      - 7477:7477
-      - 6480:6480
-      - 7690:7690
-    volumes:
-      - $HOME/tmp/docker/cluster-simple/neo4j-read1/conf:/conf
-      - $HOME/tmp/docker/cluster-simple/neo4j-read1/data:/data
-      - $HOME/tmp/docker/cluster-simple/neo4j-read1/logs:/logs
-      - $HOME/tmp/docker/cluster-simple/neo4j-read1/metrics:/metrics
-      - $HOME/tmp/docker/cluster-simple/plugins:/plugins
-    environment:
-      - NEO4J_AUTH=neo4j/changeme
-      - NEO4J_dbms_mode=READ_REPLICA
-      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
-      - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
-      - NEO4J_dbms_connector_http_listen__address=:7477
-      - NEO4J_dbms_connector_https_listen__address=:6480
-      - NEO4J_dbms_connector_bolt_listen__address=:7690
-      - NEO4J_dbms_allow__upgrade=true
-      - NEO4JLABS_PLUGINS=["apoc"]
 

--- a/simple-cluster.yml
+++ b/simple-cluster.yml
@@ -7,7 +7,7 @@ services:
 
   srv1:
     hostname: srv1
-    image: neo4j:5.1.0-enterprise
+    image: neo4j:5.1-enterprise
     networks:
       - cluster_net
     ports:
@@ -19,7 +19,6 @@ services:
       - $HOME/tmp/docker/cluster-simple/neo4j-srv1/data:/var/lib/neo4j/data
       - $HOME/tmp/docker/cluster-simple/neo4j-srv1/logs:/var/lib/neo4j/logs
       - $HOME/tmp/docker/cluster-simple/neo4j-srv1/metrics:/var/lib/neo4j/metrics
-      - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
       - NEO4J_server_cluster_system__database__mode=PRIMARY
@@ -29,22 +28,22 @@ services:
       - NEO4J_server_default__advertised__address=srv1
       - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
       - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_PLUGINS=["apoc"]
 
   srv2:
     hostname: srv2
-    image: neo4j:5.1.0-enterprise
+    image: neo4j:5.1-enterprise
     networks:
       - cluster_net
     ports:
-      - 7475:7474
-      - 6478:6477
-      - 7688:7687
+      - :7474
+      - :6477
+      - :7687
     volumes:
       - $HOME/tmp/docker/cluster-simple/neo4j-srv2/conf:/var/lib/neo4j/conf
       - $HOME/tmp/docker/cluster-simple/neo4j-srv2/data:/var/lib/neo4j/data
       - $HOME/tmp/docker/cluster-simple/neo4j-srv2/logs:/var/lib/neo4j/logs
       - $HOME/tmp/docker/cluster-simple/neo4j-srv2/metrics:/metrics
-      - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
       - NEO4J_server_cluster_system__database__mode=PRIMARY
@@ -54,22 +53,22 @@ services:
       - NEO4J_server_default__advertised__address=srv2
       - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
       - NEO4J_initial_dbms_default__primaries__count=3
+      - NEO4J_PLUGINS=["apoc"]
 
   srv3:
     hostname: srv3
-    image: neo4j:5.1.0-enterprise
+    image: neo4j:5.1-enterprise
     networks:
       - cluster_net
     ports:
-      - 7476:7474
-      - 6479:6477
-      - 7689:7687
+      - :7474
+      - :6477
+      - :7687
     volumes:
       - $HOME/tmp/docker/cluster-simple/neo4j-srv3/conf:/var/lib/neo4j/conf
       - $HOME/tmp/docker/cluster-simple/neo4j-srv3/data:/var/lib/neo4j/data
       - $HOME/tmp/docker/cluster-simple/neo4j-srv3/logs:/var/lib/neo4j/logs
       - $HOME/tmp/docker/cluster-simple/neo4j-srv3/metrics:/var/lib/neo4j/metrics
-      - $HOME/tmp/docker/cluster-simple/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/changeme
       - NEO4J_server_cluster_system__database__mode=PRIMARY
@@ -79,5 +78,5 @@ services:
       - NEO4J_server_default__advertised__address=srv3
       - NEO4J_dbms_cluster_discovery_endpoints=srv1:5000,srv2:5000,srv3:5000
       - NEO4J_initial_dbms_default__primaries__count=3
-
+      - NEO4J_PLUGINS=["apoc"]
 


### PR DESCRIPTION
 - update to Neo4j to  version 5.1.0
 - no CORE/READ_REPLICA anymore, use new cluster node types instead
 - service names changed to reflect type (coreX -> srvX)
 - streamlining port configuration, nodes using standard ports